### PR TITLE
Connection handling

### DIFF
--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -1,4 +1,3 @@
 require 'ndr_dev_support/integration_testing/capybara'
-require 'ndr_dev_support/integration_testing/connection_sharing'
 require 'ndr_dev_support/integration_testing/poltergeist'
 require 'ndr_dev_support/integration_testing/screenshot'

--- a/lib/ndr_dev_support/integration_testing/connection_sharing.rb
+++ b/lib/ndr_dev_support/integration_testing/connection_sharing.rb
@@ -1,5 +1,24 @@
 module NdrDevSupport
   module IntegrationTesting
+    # ==========================================================================
+    #
+    #                 !! Caution - please read carefully !!
+    #
+    #   This approach to connection sharing is known to be susceptible
+    #   to race conditions. Anecdotally, we've managed to avoid this
+    #   being a problem with Oracle because of the use of the confuration
+    #
+    #     ActiveRecord::Base.connection.raw_connection.non_blocking = false
+    #
+    #   which prevents the C extension in the adapter being able to run
+    #   non-blocking code (i.e. outside of the control of the global interpretter
+    #   lock). On Postgres, we haven't employed an equivalent workaround.
+    #
+    #   For a more resilient alternative, please use the 'database_cleaner'
+    #   gem (see README for details).
+    #
+    # ==========================================================================
+    #
     # Capybara starts another rails application in a new thread
     # to test against. For transactional fixtures to work, we need
     # to share the database connection between threads.


### PR DESCRIPTION
Connection sharing support is no longer included by default when requiring the integration test helpers – it appears to be the cause of non-deterministic test failures in some projects. Other projects use the functionality without issue, so it remains available in `ndr_dev_support`.