### PR TITLE
Feature/interactive

### DIFF
--- a/lib/tasks/audit_code.rake
+++ b/lib/tasks/audit_code.rake
@@ -336,7 +336,7 @@ def print_repo_file_diffs(repolatest, repo, fname, usr, safe_revision, interacti
   require 'highline/import'
 
   if interactive
-    ask("\nPress Enter to continue ...")
+    ask("\n<%= color('Press Enter to continue ...', :yellow) %>")
     system('clear')
     system("printf '\033[3J'") # clear the scrollback
   end
@@ -358,16 +358,23 @@ def print_repo_file_diffs(repolatest, repo, fname, usr, safe_revision, interacti
   end
 
   if interactive
-    response = ask("Flag #{fname} changes safe? [Yes|No|Abort]: ") { |q| q.in = %w[Yes No Abort] }
-    if response == 'Yes'
+    response = ask("Flag #{fname} changes safe? [Yes|No|Abort]: ") { |q| q.case = :down }
+    if %w[yes y].include?(response)
       puts 'Flagging as safe...'
       release = get_release(repolatest)
-      usr = ask('File reviewed by:') { |q| q.validate = /\A[\w ]+\Z/} if usr.to_s.strip.empty?
+      if usr.to_s.strip.empty?
+        usr = ask('File reviewed by:') do |q|
+          q.whitespace = :strip_and_collapse
+          q.validate = /\A[\w \-]+\Z/
+        end
+      end
       comment = ask('Please write your comments (optional):')
       # use to_s to convert response from !ruby/string:HighLine::String to String
       flag_file_as_safe(release, usr.to_s, comment.to_s, fname)
-    elsif response == 'Abort'
+    elsif %w[abort a].include?(response)
       abort('Rake abort: user interrupt detected')
+    else
+      say("\n<%= color('Safey review for #{fname} skipped by user.', :magenta) %>")
     end
   else
     puts 'To flag the changes to this file as safe, run:'

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -22,6 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'pry'
 
+  # Audit dependencies:
+  spec.add_dependency 'highline', '>= 1.6.0'
+
   # Rubocop dependencies:
   spec.add_dependency 'rubocop', '0.52.1'
   spec.add_dependency 'parser'


### PR DESCRIPTION
@timgentry asked me to add the ability to interactively code review, prompting to flag code as safe, rather than forcing the reviewer to run a separate rake task for each file. 

replace PR15, code changes in this PR extended `rake audit:code` with `interactive` switcher.

Usage: `bundle exec rake audit:code [max_print=n] [ignore_new=false|true] [show_diffs=false|true] [reviewed_by=usr] [interactive=false|true]`

e.g: `bundle exec rake audit:code reviewed_by=<username> interactive=true`

It will prompt for user's decision:
Yes - Flag file safe
No - Do nothing, skip this file
Abort - abort the rake task (equivalent to `ctrl`+`c`)

It will  also prompt for username if not provided, and optional comment when flagging the file changes safe.

Clear terminal screen  (equivalent to `cmd`+`k`) before review next file.

interactive code updated based on the diff file posted on Slack/github channel by @timgentry.