### PR TITLE
Replaced blanket db folder rubocop exclusion with cop specific exemptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,10 +44,6 @@ Style/FrozenStringLiteralComment:
   # We're not confident enough to make this recommendation everywhere
   Enabled: false
 
-Metrics/LineLength:
-  Max: 100
-  # FIXME: ExcludedMethods and Exclude don't seem to work here
-
 Style/ModuleFunction:
   # `extend self` has fewer side effects than `module_function`.
   EnforcedStyle: extend_self
@@ -102,6 +98,7 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Max: 100
   Exclude:
+  - 'db/migrate/*.rb'
   - 'test/**/*.rb'
 
 Metrics/MethodLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   # All cops should ignore files in the following locations:
   Exclude:
   - 'bin/*'
-  - 'db/**/*'
+  - 'db/schema.rb'
   - 'lib/generators/**/templates/*'
   - 'tmp/**/*'
   - 'vendor/**/*'
@@ -46,6 +46,7 @@ Style/FrozenStringLiteralComment:
 
 Metrics/LineLength:
   Max: 100
+  # FIXME: ExcludedMethods and Exclude don't seem to work here
 
 Style/ModuleFunction:
   # `extend self` has fewer side effects than `module_function`.
@@ -53,6 +54,7 @@ Style/ModuleFunction:
 
 Style/NumericLiterals:
   Exclude:
+  - 'db/migrate/*.rb'
   - 'test/**/*.rb'
 
 Style/YodaCondition:
@@ -75,6 +77,8 @@ Performance/Casecmp:
 
 Metrics/AbcSize:
   Max: 23
+  Exclude:
+  - 'db/migrate/*.rb'
 
 Metrics/BlockLength:
   # We're already limiting method size, blocks outside of methods
@@ -84,6 +88,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 150
   Exclude:
+  - 'db/migrate/*.rb'
   - 'test/**/*.rb'
 
 Metrics/ModuleLength:
@@ -102,6 +107,7 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 15
   Exclude:
+  - 'db/migrate/*.rb'
   - 'test/**/*.rb'
 
 Metrics/PerceivedComplexity:


### PR DESCRIPTION
@joshpencheon worth holding off on merging this until I work out how to fix `Metrics/LineLength`, I couldn't get `Exclude` or `ExcludedMethods` to work and willl need to look into it further. Relates to #27.