### PR TITLE
# capistrano: use passwordless sudo when installing out-of-bundle gems

### DIFF
--- a/lib/ndr_dev_support/capistrano/ndr_model.rb
+++ b/lib/ndr_dev_support/capistrano/ndr_model.rb
@@ -5,7 +5,7 @@ require_relative 'assets'
 require_relative 'restart'
 require_relative 'revision_logger'
 require_relative 'ruby_version'
-# require_relative 'standalone_gems' # This doesn't work with the permissions model
+require_relative 'standalone_gems'
 require_relative 'svn_cache'
 require_relative 'sysadmin_scripts'
 


### PR DESCRIPTION
Fixes an issue whereby capistrano couldn't install out-of-gems in NDR-model deployments