### PR TITLE
Avoid race condition when introducing minutest plugins

### DIFF
--- a/lib/minitest/rake_ci.rb
+++ b/lib/minitest/rake_ci.rb
@@ -1,0 +1,5 @@
+require 'minitest'
+
+# Autodiscover the _plugin.rb file:
+Minitest.load_plugins
+

--- a/lib/minitest/rake_ci.rb
+++ b/lib/minitest/rake_ci.rb
@@ -2,4 +2,5 @@ require 'minitest'
 
 # Autodiscover the _plugin.rb file:
 Minitest.load_plugins
+Minitest::RakeCIReporter.enable!
 

--- a/lib/minitest/rake_ci_plugin.rb
+++ b/lib/minitest/rake_ci_plugin.rb
@@ -4,8 +4,20 @@ require 'ndr_dev_support/rake_ci/concerns/commit_metadata_persistable'
 
 # The plugin needs to extend Minitest
 module Minitest
+  def self.plugin_rake_ci_init(_options)
+    reporter << RakeCIReporter.new if RakeCIReporter.enabled?
+  end
+
   # RakeCI Minitest Reporter
   class RakeCIReporter < StatisticsReporter
+    def self.enable!
+      @enabled = true
+    end
+
+    def self.enabled?
+      @enabled ||= false
+    end
+
     include CommitMetadataPersistable
 
     def report
@@ -105,9 +117,5 @@ module Minitest
     def name
       'minitest'
     end
-  end
-
-  def self.plugin_rake_ci_init(_options)
-    reporter << RakeCIReporter.new
   end
 end

--- a/lib/minitest/rake_ci_plugin.rb
+++ b/lib/minitest/rake_ci_plugin.rb
@@ -111,5 +111,3 @@ module Minitest
     reporter << RakeCIReporter.new
   end
 end
-
-Minitest.extensions << 'rake_ci'

--- a/lib/tasks/ci/minitest.rake
+++ b/lib/tasks/ci/minitest.rake
@@ -19,15 +19,15 @@ namespace :ci do
     desc 'setup'
     task :setup do
       # Load the RakeCI reporter:
-      require 'minitest/rake_ci_reporter'
+      require 'minitest/rake_ci'
 
       # Ensure spawned processes do the same:
-      ENV['RUBYOPT'] += ' -rminitest/rake_ci_reporter'
+      ENV['RUBYOPT'] += ' -rminitest/rake_ci'
     end
 
     desc 'process'
     task :process do
-      require 'minitest/rake_ci_reporter'
+      require 'minitest/rake_ci'
 
       @attachments ||= []
       @metrics ||= []


### PR DESCRIPTION
The preferred way of loading plugins is to have them in a discoverable location, and then the first plugin that is called loads all.

Directly hooking into `Minitest.extensions` prevented other plugins from being discovered after `rake_ci` loaded.