### PR TITLE
# ci_server: improve logging and error handling

### DIFF
--- a/lib/tasks/ci/minitest.rake
+++ b/lib/tasks/ci/minitest.rake
@@ -5,7 +5,6 @@ namespace :ci do
 
     # Run the tests
     test_cmd = 'bundle exec rake ci:minitest:setup ci:simplecov:setup default'
-    test_cmd += ' 2>&1 >/dev/null' if ENV['RAKECI_HEADLESS']
     system test_cmd
 
     Rake::Task['ci:minitest:process'].invoke


### PR DESCRIPTION
@timgentry,

I think I've done basically what we discussed:
* I've added in some general log messages, to give an idea of progress / point of failure
* I've added logging of exceptions, as well as some new exceptions where things should perhaps be "fatal" (e.g. git/bundle failure - less convinced about the latter..?)
* I _haven't_ gone near the `git checkout -- . && git clean -fd`, as I wasn't sure if the files the server itself generates end up in untracked locations
* I _haven't_ actually configured a separate logger in this PR; calls to `log` will still head to stdout.