### PR TITLE
# Setting the Capybara save path and prune strategy. Resolves #45

### DIFF
--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -23,3 +23,6 @@ require 'ndr_dev_support/integration_testing/drivers/switchable'
 
 Capybara.default_driver    = :switchable
 Capybara.javascript_driver = :switchable
+
+Capybara.save_path = Rails.root.join('tmp', 'screenshots')
+Capybara::Screenshot.prune_strategy = { keep: 20 }


### PR DESCRIPTION
Sets the save path to `tmp/screenshots` (in line with the Rails convention) and set the prune strategy to keep 20 screenshots.