### PR TITLE
# rake rubocop:diff now gracefully reports ruby syntax errors

### DIFF
--- a/lib/ndr_dev_support/rubocop/executor.rb
+++ b/lib/ndr_dev_support/rubocop/executor.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'open3'
 require 'shellwords'
 
 module NdrDevSupport
@@ -15,16 +16,32 @@ module NdrDevSupport
 
       def initialize(filenames)
         @filenames = Executor.target_files & filenames
+
+        check_ruby_syntax
       end
 
       def offenses_by_file
         return [] if @filenames.empty?
 
-        escaped_paths = @filenames.map { |path| Shellwords.escape(path) }
         output = JSON.parse(`rubocop --format json #{escaped_paths.join(' ')}`)
 
         output['files'].each_with_object({}) do |file_output, result|
           result[file_output['path']] = file_output['offenses']
+        end
+      end
+
+      private
+
+      def escaped_paths
+        @escaped_paths ||= @filenames.map { |path| Shellwords.escape(path) }
+      end
+
+      def check_ruby_syntax
+        escaped_paths.each do |path|
+          stdout_and_err_str, status = Open3.capture2e("ruby -c #{path}")
+          next if status.exitstatus.zero?
+
+          raise stdout_and_err_str
         end
       end
     end


### PR DESCRIPTION
If amended code has a syntax error (e.g. a missing `end`), the `ruby -c` syntax error is now raised, rather than a spurious RuboCop error message.