### PR TITLE
# switch to webdrivers from chromedriver-helper. Resolves #53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Use `webdrivers` gem for Selenium WebDriver managements.
 
 ## 5.3.0 / 2019-05-15
 ### Added

--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -18,6 +18,10 @@ end
 # Include our custom DSL extensions, that also cover screenshotting:
 require 'ndr_dev_support/integration_testing/dsl'
 
+# Keeps the selenium webdrivers automatically updated:
+require 'webdrivers'
+Webdrivers.cache_time = 24.hours
+
 # These are all the drivers we have capybara / screenshot support for:
 require 'ndr_dev_support/integration_testing/drivers/chrome'
 require 'ndr_dev_support/integration_testing/drivers/chrome_headless'

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome.rb
@@ -1,4 +1,3 @@
-require 'chromedriver-helper'
 require 'selenium-webdriver'
 
 Capybara.register_driver(:chrome) do |app|

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
@@ -1,4 +1,3 @@
-require 'chromedriver-helper'
 require 'selenium-webdriver'
 
 Capybara.register_driver(:chrome_headless) do |app|

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
   # Integration test dependencies:
   spec.add_dependency 'capybara'
   spec.add_dependency 'capybara-screenshot'
-  spec.add_dependency 'chromedriver-helper', '~> 2.0'
   spec.add_dependency 'poltergeist', '>= 1.8.0'
   spec.add_dependency 'selenium-webdriver'
+  spec.add_dependency 'webdrivers', '>= 3.9'
 
   # CI server dependencies:
   spec.add_dependency 'activesupport', '< 6.1'


### PR DESCRIPTION
The `chromedriver-helper` library is no longer being maintained, and the de-facto path is to switch to `webdrivers`.