### PR TITLE
Chrome and cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
-*no unreleased changes*
+### Added
+* Introduce `show_me_the_cookies` into the integration testing DSL
+
+### Fixed
+* Use command line args to prevent headless Chrome hanging
 
 ## 5.3.1 / 2019-05-20
 ### Fixed

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome.rb
@@ -1,4 +1,5 @@
 require 'selenium-webdriver'
+require 'show_me_the_cookies'
 
 Capybara.register_driver(:chrome) do |app|
   Capybara::Selenium::Driver.new app, browser: :chrome
@@ -7,3 +8,5 @@ end
 Capybara::Screenshot.register_driver(:chrome) do |driver, path|
   driver.browser.save_screenshot(path)
 end
+
+ShowMeTheCookies.register_adapter(:chrome, ShowMeTheCookies::SeleniumChrome)

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
@@ -1,4 +1,5 @@
 require 'selenium-webdriver'
+require 'show_me_the_cookies'
 
 Capybara.register_driver(:chrome_headless) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
@@ -21,3 +22,5 @@ end
 Capybara::Screenshot.register_driver(:chrome_headless) do |driver, path|
   driver.browser.save_screenshot(path)
 end
+
+ShowMeTheCookies.register_adapter(:chrome_headless, ShowMeTheCookies::SeleniumChrome)

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
@@ -2,7 +2,13 @@ require 'selenium-webdriver'
 
 Capybara.register_driver(:chrome_headless) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    'chromeOptions' => { args: %w[headless disable-gpu] }
+    chromeOptions: {
+      args: %w[
+        headless disable-gpu no-sandbox
+        --window-size=1920,1080
+        --enable-features=NetworkService,NetworkServiceInProcess
+      ]
+    }
   )
 
   Capybara::Selenium::Driver.new(

--- a/lib/ndr_dev_support/integration_testing/drivers/firefox.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/firefox.rb
@@ -1,4 +1,5 @@
 require 'selenium-webdriver'
+require 'show_me_the_cookies'
 
 Capybara.register_driver(:firefox) do |app|
   Capybara::Selenium::Driver.new app, browser: :firefox
@@ -7,3 +8,5 @@ end
 Capybara::Screenshot.register_driver(:firefox) do |driver, path|
   driver.browser.save_screenshot(path)
 end
+
+ShowMeTheCookies.register_adapter(:firefox, ShowMeTheCookies::Selenium)

--- a/lib/ndr_dev_support/integration_testing/drivers/poltergeist.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/poltergeist.rb
@@ -1,5 +1,6 @@
 # The driver for PhantomJS is poltergeist:
 require 'capybara/poltergeist'
+require 'show_me_the_cookies'
 
 Capybara.register_driver(:poltergeist) do |app|
   options = { phantomjs_options: ['--proxy-type=none'], timeout: 60 }
@@ -13,3 +14,5 @@ Capybara::Screenshot.register_driver(:poltergeist) do |driver, path|
   # Take full-height screenshots, rather than just capturing the viewport:
   driver.render(path, full: true)
 end
+
+ShowMeTheCookies.register_adapter(:poltergeist, ShowMeTheCookies::Poltergeist)

--- a/lib/ndr_dev_support/integration_testing/drivers/switchable.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/switchable.rb
@@ -1,21 +1,32 @@
-# A meta-driver that allows the driver to be set using the `INTEGRATION_DRIVER`
-# environment variable (e.g. for a CI matrix), assuming that driver has been pre-registered
-# with Capybara.
+require 'show_me_the_cookies'
 
-# Although the aim is to move to Chrome headless, we keep poltergeist as the default
-# driver for now. For motivation behind not changing immediately, see the "Differences
-# between Poltergeist and Selenium" section of:
-#
-#   https://about.gitlab.com/2017/12/19/moving-to-headless-chrome/
-#
-Capybara.register_driver(:switchable) do |app|
-  choice = ENV.fetch('INTEGRATION_DRIVER', 'poltergeist').to_sym
+module NdrDevSupport
+  module IntegrationTesting
+    module Drivers
+      # A meta-driver that allows the driver to be set using the `INTEGRATION_DRIVER`
+      # environment variable (e.g. for a CI matrix), assuming that driver has been pre-registered
+      # with Capybara.
 
-  Capybara.drivers.fetch(choice).call(app)
-end
+      # Although the aim is to move to Chrome headless, we keep poltergeist as the default
+      # driver for now. For motivation behind not changing immediately, see the "Differences
+      # between Poltergeist and Selenium" section of:
+      #
+      #   https://about.gitlab.com/2017/12/19/moving-to-headless-chrome/
+      #
+      module Switchable
+        DEFAULT    = :poltergeist
+        CONFIGURED = ENV.fetch('INTEGRATION_DRIVER', DEFAULT).to_sym
 
-Capybara::Screenshot.register_driver(:switchable) do |driver, path|
-  choice = ENV.fetch('INTEGRATION_DRIVER', 'poltergeist').to_sym
+        Capybara.register_driver(:switchable) do |app|
+          Capybara.drivers.fetch(CONFIGURED).call(app)
+        end
 
-  Capybara::Screenshot.registered_drivers.fetch(choice).call(driver, path)
+        Capybara::Screenshot.register_driver(:switchable) do |driver, path|
+          Capybara::Screenshot.registered_drivers.fetch(CONFIGURED).call(driver, path)
+        end
+
+        ShowMeTheCookies.register_adapter(:switchable, ShowMeTheCookies.adapters.fetch(CONFIGURED))
+      end
+    end
+  end
 end

--- a/lib/ndr_dev_support/integration_testing/dsl.rb
+++ b/lib/ndr_dev_support/integration_testing/dsl.rb
@@ -1,20 +1,25 @@
 require 'capybara/rails'
+require 'show_me_the_cookies'
 
 module NdrDevSupport
   module IntegrationTesting
     # Additional integration testing DSL:
     module DSL
-      # Instruct the headless browser to clear its session:
+      include ShowMeTheCookies
+
+      # Instruct the browser to clear its session:
       def clear_headless_session!
         page.driver.reset!
       end
 
-      # Get the headless browser to delete all of the cookies
+      # Get the browser to delete all of the cookies
       # for the current page without resetting:
       def delete_all_cookies!
-        page.driver.cookies.each_key do |name|
-          page.driver.remove_cookie(name)
-        end
+        ActiveSupport::Deprecation.warn(<<~MSG)
+          `delete_all_cookies!` is deprecated in favour of `expire_cookies`
+        MSG
+
+        expire_cookies
       end
 
       # Wrap up interacting with modals. The assumption is that the modal

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'unicode-display_width', '>= 1.3.3'
 
   # Integration test dependencies:
-  spec.add_dependency 'capybara'
+  spec.add_dependency 'capybara', '>= 3.20'
   spec.add_dependency 'capybara-screenshot'
   spec.add_dependency 'poltergeist', '>= 1.8.0'
   spec.add_dependency 'selenium-webdriver'

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capybara-screenshot'
   spec.add_dependency 'poltergeist', '>= 1.8.0'
   spec.add_dependency 'selenium-webdriver'
+  spec.add_dependency 'show_me_the_cookies'
   spec.add_dependency 'webdrivers', '>= 3.9'
 
   # CI server dependencies:


### PR DESCRIPTION
Uses command line args to prevent headless Chrome hanging: https://bugs.chromium.org/p/chromedriver/issues/detail?id=2885

Also adds in the `show_me_the_cookies` gem, to allow for a browser-agnostic way of accessing the cookies.