### PR TITLE
Turned off the Rails/RefuteMethods cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,6 +116,9 @@ Rails/DynamicFindBy:
   Exclude:
   - 'test/integration/**/*.rb'
 
+Rails/RefuteMethods:
+  Enable: false
+
 Rails/SkipsModelValidations:
   # Methods like 'update_column' exist for a reason, and it is the developer's
   # responsibilty to understand the behaviour of the code they write; blanket

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,7 +117,7 @@ Rails/DynamicFindBy:
   - 'test/integration/**/*.rb'
 
 Rails/RefuteMethods:
-  Enable: false
+  Enabled: false
 
 Rails/SkipsModelValidations:
   # Methods like 'update_column' exist for a reason, and it is the developer's


### PR DESCRIPTION
Please merge if you're happy with the change.  I'm not sure what happens with the version number for changes to the rubcicop.yml as it is pulled directly from GitHub rather than via the gem.