### PR TITLE
Flakey tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Added
+* Add `flakey_test` to the minitest DSL, to allow sporadic failures to be retried
 
 ## 5.5.0 / 2020-01-27
 * bundle master RuboCop config, and allow it to be `required`

--- a/README.md
+++ b/README.md
@@ -135,6 +135,27 @@ Beyond standard Capybara testing DSL, ndr_dev_support bundles some additional fu
 
 When using a headless browser for integration tests, the test database must be consistent between the test runner and the application being tested. With transactional tests in operation, this means that both must share a connection. It is up to the individual project to provide this facility; as of Rails 5.1, it is built in to the framework directly.
 
+#### Flakey Tests
+
+It is an unfortunate reality that sometimes tests are written that will fail sporadically. Whilst in such cases the test methodology should be addressed, investigations can be time-consuming.
+Therefore, `ndr_dev_support` grudgingly provides "flakey test" support, to minimise disruption to CI pipelines whilst root causes are investigated.
+
+```ruby
+test 'thing that always passes' do
+  # reliable test
+end
+
+flakey_test 'thing that occassionally needs a second or third attempt' do
+  # less reliable test
+end
+
+flakey_test 'thing that often needs multiple attempts', attempts: 10 do
+  # really unreliable test (gulp...)
+end
+```
+
+If tests still fail, they'll fail as normal. If tests pass after flakey failure, they'll be flagged to the RakeCI server, and rendered in purple on Slack.
+
 ### Deployment support
 
 There are various capistrano plugins in the `ndr_dev_support/capistrano` directory - see each one for details.

--- a/lib/minitest/rake_ci_plugin.rb
+++ b/lib/minitest/rake_ci_plugin.rb
@@ -9,6 +9,29 @@ module Minitest
     reporter << RakeCIReporter.new if RakeCIReporter.enabled?
   end
 
+  # Intermediate Reporter than can also track flakey failures
+  class FlakeyStatisticsReporter < StatisticsReporter
+    attr_accessor :flakey_results
+
+    def initialize(*)
+      super
+
+      self.flakey_results = []
+    end
+
+    def record(result)
+      super
+
+      return unless result.respond_to?(:flakes)
+
+      flakey_results << result if result.flakes.any?
+    end
+
+    def flakes
+      flakey_results.sum { |result| result.flakes.length }
+    end
+  end
+
   # RakeCI Minitest Reporter
   class RakeCIReporter < StatisticsReporter
     def self.enable!

--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -18,6 +18,9 @@ end
 # Include our custom DSL extensions, that also cover screenshotting:
 require 'ndr_dev_support/integration_testing/dsl'
 
+# Include support for retrying tests that sporadically fail:
+require 'ndr_dev_support/integration_testing/flakey_tests'
+
 # Keeps the selenium webdrivers automatically updated:
 require 'webdrivers'
 Webdrivers.cache_time = 24.hours

--- a/lib/ndr_dev_support/integration_testing/flakey_tests.rb
+++ b/lib/ndr_dev_support/integration_testing/flakey_tests.rb
@@ -1,0 +1,55 @@
+module NdrDevSupport
+  module IntegrationTesting
+    # Grudging handling of flakey integration tests. Allows tests to be declared
+    # with `flakey_test`. Our CI reporter gathers information on flakey failures.
+    module FlakeyTests
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :attempts_per_test, default: {}
+      end
+
+      class_methods do
+        def flakey_test(description, attempts: 3, &block)
+          test(description, &block).tap do |test_name|
+            self.attempts_per_test = attempts_per_test.merge(test_name.to_s => attempts)
+          end
+        end
+      end
+
+      def flakes
+        @flakes ||= []
+      end
+
+      def run
+        attempts_remaining = attempts_per_test[name]
+        return super unless attempts_remaining
+
+        previous_failure = failures.last
+        attempts = []
+
+        loop do
+          break if attempts_remaining < 1
+
+          super
+
+          # No failure was added; we passed!
+          break if failures.last == previous_failure
+
+          # Ran out of attempts:
+          break if (attempts_remaining -= 1) < 1
+
+          # Loop round and have another go:
+          attempts << failures.pop
+        end
+
+        # Attempts were only flakey if we eventually passed:
+        flakes.concat(attempts) if failures.last == previous_failure
+
+        self
+      end
+    end
+  end
+end
+
+ActionDispatch::IntegrationTest.include(NdrDevSupport::IntegrationTesting::FlakeyTests)

--- a/lib/ndr_dev_support/integration_testing/flakey_tests.rb
+++ b/lib/ndr_dev_support/integration_testing/flakey_tests.rb
@@ -26,7 +26,7 @@ module NdrDevSupport
         return super unless attempts_remaining
 
         previous_failure = failures.last
-        attempts = []
+        failed_attempts = []
 
         loop do
           break if attempts_remaining < 1
@@ -40,11 +40,11 @@ module NdrDevSupport
           break if (attempts_remaining -= 1) < 1
 
           # Loop round and have another go:
-          attempts << failures.pop
+          failed_attempts << failures.pop
         end
 
         # Attempts were only flakey if we eventually passed:
-        flakes.concat(attempts) if failures.last == previous_failure
+        flakes.concat(failed_attempts) if failures.last == previous_failure
 
         self
       end

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   # Integration test dependencies:
   spec.add_dependency 'capybara', '>= 3.20'
   spec.add_dependency 'capybara-screenshot'
+  spec.add_dependency 'minitest', '~> 5.0'
   spec.add_dependency 'poltergeist', '>= 1.8.0'
   spec.add_dependency 'selenium-webdriver'
   spec.add_dependency 'show_me_the_cookies'
@@ -55,7 +56,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano', '~> 2.15'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Adds a `flakey_test` method to minitest's DSL. Positioning as a pragmatic necessary evil, given CI pipelines are being affected.

If a test declared as "flakey" fails, but then passes after retries, it will be reported as a Pass. However, the CI will additional report it as being flakey (in a purple bubble to Slack).