### PR TITLE
Seed reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 * Add `flakey_test` to the minitest DSL, to allow sporadic failures to be retried
+* CI: include minitest seed in slack output
 
 ## 5.5.0 / 2020-01-27
 * bundle master RuboCop config, and allow it to be `required`

--- a/lib/minitest/rake_ci_plugin.rb
+++ b/lib/minitest/rake_ci_plugin.rb
@@ -5,8 +5,8 @@ require 'ndr_dev_support/rake_ci/concerns/commit_metadata_persistable'
 
 # The plugin needs to extend Minitest
 module Minitest
-  def self.plugin_rake_ci_init(_options)
-    reporter << RakeCIReporter.new if RakeCIReporter.enabled?
+  def self.plugin_rake_ci_init(options)
+    reporter << RakeCIReporter.new(options[:io], options) if RakeCIReporter.enabled?
   end
 
   # Intermediate Reporter than can also track flakey failures
@@ -141,7 +141,7 @@ module Minitest
       {
         color: 'danger',
         text: 'test failure'.pluralize(failures) + failure_snippets,
-        footer: 'bundle exec rake ci:minitest'
+        footer: footer
       }
     end
 
@@ -149,7 +149,7 @@ module Minitest
       {
         color: '#bb44ff',
         text: 'flakey test'.pluralize(flakes) + flake_snippets,
-        footer: 'bundle exec rake ci:minitest'
+        footer: footer
       }
     end
 
@@ -157,7 +157,7 @@ module Minitest
       {
         color: 'warning',
         text: 'test error'.pluralize(errors) + error_snippets,
-        footer: 'bundle exec rake ci:minitest'
+        footer: footer
       }
     end
 
@@ -165,7 +165,7 @@ module Minitest
       {
         color: 'good',
         text: newly_passing? ? 'Tests now pass! :tada:' : 'Tests passed',
-        footer: 'bundle exec rake ci:minitest'
+        footer: footer
       }
     end
 
@@ -185,6 +185,10 @@ module Minitest
 
     def name
       'minitest'
+    end
+
+    def footer
+      "bundle exec rake ci:minitest --seed #{options[:seed]}"
     end
   end
 end

--- a/lib/tasks/ci/redmine.rake
+++ b/lib/tasks/ci/redmine.rake
@@ -41,7 +41,8 @@ namespace :ci do
       resolved_tickets.map! { |ticket_id| "https://#{hostname}/issues/#{ticket_id}" }
 
       old_attachment = @attachments.detect { |att| att[:text] =~ /Tests( now)? pass/ }
-      basic_text     = old_attachment.try(:[], :text) || 'Tests passed'
+      basic_text = old_attachment.try(:[], :text) || 'Tests passed'
+      footer = old_attachment.try(:[], :footer) || 'bundle exec rake ci:minitest'
 
       @attachments.delete(old_attachment) if old_attachment
 
@@ -51,7 +52,7 @@ namespace :ci do
         title: "#{issue_s.capitalize} Resolved",
         text: "#{basic_text}, so #{issue_s} #{resolved_tickets.join(', ')}" \
               " #{resolved_tickets.count == 1 ? 'has' : 'have'} been resolved",
-        footer: 'bundle exec rake ci:minitest',
+        footer: footer,
         mrkdwn_in: ['text']
       }
       @attachments << attachment


### PR DESCRIPTION
This PR adds the minitest seed used to the output sent to slack, to aid in local reproduction when things don't go to plan.