### PR TITLE
# add Ruby 3.0 to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-- 2.5
 - 2.6
+- 2.7
+- 3.0
 gemfile:
 - gemfiles/Gemfile.rails52
 - gemfiles/Gemfile.rails60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Fixed
 * Fix unnecessary 'parser/current' warnings when not using rubocop
+* Test against Ruby 3.0
 
 ## 5.8.2 / 2020-07-22
 ### Fixed

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'pry'
 


### PR DESCRIPTION
With the [release of Ruby 3.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/), this PR adds test coverage to NDR's base gem for the new Ruby version.