### PR TITLE
Merge v5.8.2 changes from 2020-07 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 *no unreleased changes*
 
+### Fixed
+* Tweak integration testing driver config, for capybara 3.33.0 deprecations
+
 ## 5.8.1 / 2020-07-10
 ### Fixed
 * Fix issue running `brakeman:fingerprint_details` task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 *no unreleased changes*
 
+## 5.8.2 / 2020-07-22
 ### Fixed
 * Tweak integration testing driver config, for capybara 3.33.0 deprecations
 

--- a/lib/ndr_dev_support/integration_testing/drivers/switchable.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/switchable.rb
@@ -18,14 +18,23 @@ module NdrDevSupport
         CONFIGURED = ENV.fetch('INTEGRATION_DRIVER', DEFAULT).to_sym
 
         Capybara.register_driver(:switchable) do |app|
-          Capybara.drivers.fetch(CONFIGURED).call(app)
+          configured_driver = Capybara.drivers[CONFIGURED]
+          raise "Driver #{CONFIGURED} not found!" unless configured_driver
+
+          configured_driver.call(app)
         end
 
         Capybara::Screenshot.register_driver(:switchable) do |driver, path|
-          Capybara::Screenshot.registered_drivers.fetch(CONFIGURED).call(driver, path)
+          configured_screenshot_driver = Capybara::Screenshot.registered_drivers[CONFIGURED]
+          raise "Screenshot driver #{CONFIGURED} not found!" unless configured_screenshot_driver
+
+          configured_screenshot_driver.call(driver, path)
         end
 
-        ShowMeTheCookies.register_adapter(:switchable, ShowMeTheCookies.adapters.fetch(CONFIGURED))
+        cookie_driver = ShowMeTheCookies.adapters[CONFIGURED]
+        raise "Cookie driver #{CONFIGURED} not found!" unless cookie_driver
+
+        ShowMeTheCookies.register_adapter(:switchable, cookie_driver)
       end
     end
   end

--- a/lib/ndr_dev_support/version.rb
+++ b/lib/ndr_dev_support/version.rb
@@ -2,5 +2,5 @@
 # This defines the NdrDevSupport version. If you change it, rebuild and commit the gem.
 # Use "rake build" to build the gem, see rake -T for all bundler rake tasks (and our own).
 module NdrDevSupport
-  VERSION = '5.8.1'.freeze
+  VERSION = '5.8.2'.freeze
 end


### PR DESCRIPTION
ndr_dev_support v5.8.2 was released 2020-07, but the changes were only tagged, and never merged back to the master branch.