### PR TITLE
Use up-to-date Rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased]
+### Added
+* Move to keep up with Rubocop releases
+* Add `rubocop-rake`, for additional rake-specific Rubocop checks
+
 ### Fixed
 * Fix unnecessary 'parser/current' warnings when not using rubocop
 

--- a/config/rubocop/ndr.yml
+++ b/config/rubocop/ndr.yml
@@ -8,6 +8,10 @@ require:
   - rubocop-rails
 
 AllCops:
+  # Given we take a "follow the herd" approach, with this file
+  # containing just deviations, enable new cops by default.
+  NewCops: enable
+
   # All cops should ignore files in the following locations:
   Exclude:
   - 'bin/*'
@@ -126,6 +130,11 @@ Rails/ActionFilter:
 Rails/DynamicFindBy:
   Exclude:
   - 'test/integration/**/*.rb'
+
+Rails/RakeEnvironment:
+  # Particularly without spring, this can make things that should be quick
+  # slower than desirable.
+  Enabled: false
 
 Rails/RefuteMethods:
   Enabled: false

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'ndr_dev_support/version'
 
@@ -29,8 +29,9 @@ Gem::Specification.new do |spec|
   # Rubocop dependencies:
   spec.add_dependency 'parser'
   spec.add_dependency 'rainbow'
-  spec.add_dependency 'rubocop', '0.79.0'
-  spec.add_dependency 'rubocop-rails', '2.4.1'
+  spec.add_dependency 'rubocop', '~> 1.7'
+  spec.add_dependency 'rubocop-rake', '~> 0.5'
+  spec.add_dependency 'rubocop-rails', '~> 2.9'
   spec.add_dependency 'unicode-display_width', '>= 1.3.3'
 
   # Integration test dependencies:


### PR DESCRIPTION
## Summary

This PR relaxes the dependency on `rubocop` / `rubocop-rails`, in line with [our policy](https://github.com/publichealthengland/ndr_dev_support/blob/master/config/rubocop/ndr.yml#L1-L3) of sticking with the wider Ruby community's shared consensus by default.

Additionally, we add [`rubocop-rake`](https://github.com/rubocop-hq/rubocop-rake), which runs some basic sanity checks that are helpful given Rake's DSL doesn't always behave as might be expected. (These checks would've saved my bacon in the past!)

The driver here is that the version of Rubocop we're currently locked on blocks Ruby upgrade paths.


### Other notes

It may also be worth investigating the [`rubocop-minitest`](https://docs.rubocop.org/rubocop-minitest) extension as a separate PR.