### PR TITLE
Update NDR Rubocop config

### DIFF
--- a/config/rubocop/ndr.yml
+++ b/config/rubocop/ndr.yml
@@ -6,6 +6,7 @@
 
 require:
   - rubocop-rails
+  - rubocop-rake
 
 AllCops:
   # Given we take a "follow the herd" approach, with this file


### PR DESCRIPTION
## Summary

PR #83 introduced `rubocop-rake`, but didn't add it to the actual Rubocop base configuration that our projects inherit from.

This PR ensures that the new Cops get loaded.