### PR TITLE
Add 'test_repeatedly', for help with flakey tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If tests still fail, they'll fail as normal. If tests pass after flakey failure,
 
 #### Repeating Flakey Tests
 
-To aid with investigations into potentially-flakey specs, `ndr_dev_support` also provides the ability to run a test repeatedly (by default, 100 times):
+To aid with investigations into potentially-flakey tests, `ndr_dev_support` also provides the ability to run an integration test repeatedly (by default, 100 times):
 
 ```ruby
 test_repeatedly 'thing that we think might fail' do

--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ end
 
 If tests still fail, they'll fail as normal. If tests pass after flakey failure, they'll be flagged to the RakeCI server, and rendered in purple on Slack.
 
+#### Repeating Flakey Tests
+
+To aid with investigations into potentially-flakey specs, `ndr_dev_support` also provides the ability to run a test repeatedly (by default, 100 times):
+
+```ruby
+test_repeatedly 'thing that we think might fail' do
+  # something flakey
+end
+
+test_repeatedly 'thing that we think might fail very occassionally', times: 1000 do
+  # something slightly flakey
+end
+```
+
+This may be faster to work with than repeatedly executing the entire test runner in a bash loop, for example.
+
 ### Deployment support
 
 There are various capistrano plugins in the `ndr_dev_support/capistrano` directory - see each one for details.

--- a/lib/ndr_dev_support/integration_testing/flakey_tests.rb
+++ b/lib/ndr_dev_support/integration_testing/flakey_tests.rb
@@ -15,6 +15,12 @@ module NdrDevSupport
             self.attempts_per_test = attempts_per_test.merge(test_name.to_s => attempts)
           end
         end
+
+        def test_repeatedly(description, times: 100, &block)
+          (1..times).map do |n|
+            test("#{description} - #{n}/#{times}", &block)
+          end
+        end
       end
 
       def flakes


### PR DESCRIPTION
## Issue Summary

Often, when investigating whether a test is flakey, it's helpful to be able to run a test multiple times. This tends to get done by either using a bash loop (which can be slow) or hacking about in the test file (which can get messy).

Using a bash loop to repeatedly instantiate a runner is slow:

```bash
for i in `seq 1 100`; do bin/rails test path/to/test.rb:123; done
```

And mucking around duplicating the test gets messy:

```diff
+ 100.times do |x|
- test 'something flakey' do
-   # ...
- end
+   test "something flakey - #{x}" do
+     # ...
+   end
+ end
```

## This PR

This PR adds the `test_repeatedly` construct, to make the latter pattern (which executes more efficiently) quick and simple to do, whilst retaining some configurability.

```diff
- test 'something flakey' do
+ test_repeatedly 'something flakey' do
    # 
  end
```