### PR TITLE
Capybara: use animation-disabling middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 * Move to keep up with Rubocop releases
 * Add `rubocop-rake`, for additional rake-specific Rubocop checks
+* Disable browser animations in the test environment by default
 
 ### Fixed
 * Fix unnecessary 'parser/current' warnings when not using rubocop

--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -35,5 +35,8 @@ require 'ndr_dev_support/integration_testing/drivers/switchable'
 Capybara.default_driver    = :switchable
 Capybara.javascript_driver = :switchable
 
+# Inject middleware to disable jQuery fx, CSS transitions/animations
+Capybara.disable_animation = true
+
 Capybara.save_path = Rails.root.join('tmp', 'screenshots')
 Capybara::Screenshot.prune_strategy = { keep: 20 }

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'unicode-display_width', '>= 1.3.3'
 
   # Integration test dependencies:
-  spec.add_dependency 'capybara', '>= 3.20'
+  spec.add_dependency 'capybara', '>= 3.34'
   spec.add_dependency 'capybara-screenshot'
   spec.add_dependency 'minitest', '~> 5.0'
   spec.add_dependency 'poltergeist', '>= 1.8.0'


### PR DESCRIPTION
## Summary

Recent versions of Capybara can [automatically inject](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/server/animation_disabler.rb) an additional middleware in the test environment, that appends animation-disabling statements to the end of the `<head>`. This will neuter all jQuery animations, and CSS animations/transitions.

This PR enables this middleware by default, and bumps the capybara requirement to the latest release, to get the most animation-disabling potential.