### PR TITLE
# use utility action to collate matrix results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
           - gemfiles/Gemfile.rails52
           - gemfiles/Gemfile.rails60
 
+    name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
+
     runs-on: ubuntu-latest
 
     env:
@@ -30,11 +32,23 @@ jobs:
     - name: Run tests
       run: bundle exec rake
 
+  # A utility job upon which Branch Protection can depend,
+  # thus remaining agnostic of the matrix.
+  test_matrix:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Matrix
+    needs: test
+    steps:
+    - name: Check build matrix status
+      if: ${{ needs.test.result != 'success' }}
+      run: exit 1
+
   notify:
     # Run only on master, but regardless of whether tests past:
     if: ${{ always() && github.ref == 'refs/heads/master' }}
 
-    needs: test
+    needs: test_matrix
 
     runs-on: ubuntu-latest
 
@@ -49,8 +63,8 @@ jobs:
             username: 'CI – ' + '${{ github.repository }}'.split('/')[1],
             icon_emoji: ':hammer_and_wrench:',
             attachments: [{
-              color: '${{ needs.test.result }}' === 'success' ? 'good' : '${{ needs.test.result }}' === 'failure' ? 'danger' : 'warning',
-              text: `${process.env.AS_WORKFLOW} against \`${{ github.ref }}\` (${process.env.AS_COMMIT}) for ${{ github.actor }} resulted in *${{ needs.test.result }}*.`
+              color: '${{ needs.test_matrix.result }}' === 'success' ? 'good' : '${{ needs.test_matrix.result }}' === 'failure' ? 'danger' : 'warning',
+              text: `${process.env.AS_WORKFLOW} against \`${{ github.ref }}\` (${process.env.AS_COMMIT}) for ${{ github.actor }} resulted in *${{ needs.test_matrix.result }}*.`
             }]
           }
       env:


### PR DESCRIPTION
This PR adds a new job that collates the result of the build matrix jobs; this means the repository's branch protection rules can target a single job.