### PR TITLE
# Add CODEOWNERS, with admins owning the version file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Admins should have oversight of the version:
+lib/ndr_dev_support/version.rb      @ndr-admins


### PR DESCRIPTION
## Summary

When we being to require code review, we primarily want to keep the process as open as possible.

However, one exception is the `version.rb` file, which is used during the release process (and changes to which might in future trigger a release automatically).

This PR, along with appropriate branch protection rules, ensures that changes to `version.rb` are signed off by an NDR admin.

