### PR TITLE
# Suppress some parser/current warnings

### DIFF
--- a/lib/ndr_dev_support/rubocop/executor.rb
+++ b/lib/ndr_dev_support/rubocop/executor.rb
@@ -10,7 +10,7 @@ module NdrDevSupport
       class << self
         # Use RuboCop to produce a list of all files that should be scanned.
         def target_files
-          @target_files ||= `rubocop -L`.each_line.map(&:strip)
+          @target_files ||= `rubocop -L 2>/dev/null`.each_line.map(&:strip)
         end
       end
 
@@ -23,7 +23,7 @@ module NdrDevSupport
       def offenses_by_file
         return [] if @filenames.empty?
 
-        output = JSON.parse(`rubocop --format json #{escaped_paths.join(' ')}`)
+        output = JSON.parse(`rubocop --format json #{escaped_paths.join(' ')} 2>/dev/null`)
 
         output['files'].each_with_object({}) do |file_output, result|
           result[file_output['path']] = file_output['offenses']

--- a/lib/ndr_dev_support/rubocop/inject.rb
+++ b/lib/ndr_dev_support/rubocop/inject.rb
@@ -1,4 +1,12 @@
-require 'rubocop'
+require 'stringio'
+
+begin
+  # Go nuclear on "warning: parser/current ..."
+  $stderr = StringIO.new
+  require 'rubocop'
+ensure
+  $stderr = STDERR
+end
 
 module NdrDevSupport
   module Rubocop

--- a/lib/ndr_dev_support/rubocop/range_finder.rb
+++ b/lib/ndr_dev_support/rubocop/range_finder.rb
@@ -1,6 +1,5 @@
 require 'English'
 require 'open3'
-require 'rubocop'
 require 'shellwords'
 
 module NdrDevSupport


### PR DESCRIPTION
## Issue Summary

The `parser` library quite rightly warns loudly when the exact version of Ruby it is expecting doesn't match the active Ruby (given a history of syntax validity changes even within tiny version bumps of Ruby).

However, these warnings are popping up in unexpected places, and are just noise - so get ignored.

## PR Summary

Given that Rubocop itself now loads `parser/current`, ndr_dev_support (which is a dependency of all of our projects) triggers it too (by virtue of acting as a Rubocop plugin).

This PR preserves the warnings when they're relevant:

```
$ bundle exec rake rubocop:diff master
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
================================== Summary: ==================================
 * lib/ndr_dev_support/rubocop/executor.rb has 0 relevant offences.
 * lib/ndr_dev_support/rubocop/inject.rb has 0 relevant offences.
 * lib/ndr_dev_support/rubocop/range_finder.rb has 0 relevant offences.
==============================================================================
```

...but suppresses them when they're not:

```
$ bundle exec rake
Run options: --seed 17038

# Running:

.......................................

Finished in 0.072500s, 537.9310 runs/s, 993.1034 assertions/s.

39 runs, 72 assertions, 0 failures, 0 errors, 0 skips
```