### PR TITLE
Allow usage / test against with Rails 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         gemfile:
           - gemfiles/Gemfile.rails52
           - gemfiles/Gemfile.rails60
+          - gemfiles/Gemfile.rails61
 
     name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
 

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-
 gemspec path: '..'
 
 gem 'activesupport', '~> 5.2.0'

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec path: '..'
 
-gem 'activesupport', '~> 6.0.0'
+gem 'activesupport', '~> 6.1.0'

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'webdrivers', '>= 3.9'
 
   # CI server dependencies:
-  spec.add_dependency 'activesupport', '< 6.1'
+  spec.add_dependency 'activesupport', '< 7'
   spec.add_dependency 'brakeman', '>= 4.7.1'
   spec.add_dependency 'bundler-audit'
   spec.add_dependency 'github-linguist'


### PR DESCRIPTION
This PR relaxes the gem dependency against `active_support`, and ensures we're testing against the in-support minor version series of Rails.

The next release of Rails is [due to be 7.x](https://twitter.com/bitsweat/status/1357897202299850752), but given it is evidently going to have breaking changes I've prevented `ndr_dev_support` from automatically working with it.