### PR TITLE
# Address issue with flakey_test / minitest 5.11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Fixed an issue using `flakey_test` with `minitest` v5.11 onwards
 
 ## 5.10.1 / 2021-02-01
 ### Fixed

--- a/lib/ndr_dev_support/integration_testing/flakey_tests.rb
+++ b/lib/ndr_dev_support/integration_testing/flakey_tests.rb
@@ -33,11 +33,12 @@ module NdrDevSupport
 
         previous_failure = failures.last
         failed_attempts = []
+        result = nil
 
         loop do
           break if attempts_remaining < 1
 
-          super
+          result = super
 
           # No failure was added; we passed!
           break if failures.last == previous_failure
@@ -52,7 +53,7 @@ module NdrDevSupport
         # Attempts were only flakey if we eventually passed:
         flakes.concat(failed_attempts) if failures.last == previous_failure
 
-        self
+        result
       end
     end
   end

--- a/lib/ndr_dev_support/integration_testing/flakey_tests.rb
+++ b/lib/ndr_dev_support/integration_testing/flakey_tests.rb
@@ -59,4 +59,6 @@ module NdrDevSupport
   end
 end
 
-ActionDispatch::IntegrationTest.include(NdrDevSupport::IntegrationTesting::FlakeyTests)
+if defined?(ActionDispatch)
+  ActionDispatch::IntegrationTest.include(NdrDevSupport::IntegrationTesting::FlakeyTests)
+end

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   # Integration test dependencies:
   spec.add_dependency 'capybara', '>= 3.34'
   spec.add_dependency 'capybara-screenshot'
-  spec.add_dependency 'minitest', '~> 5.0'
+  spec.add_dependency 'minitest', '~> 5.11'
   spec.add_dependency 'poltergeist', '>= 1.8.0'
   spec.add_dependency 'selenium-webdriver'
   spec.add_dependency 'show_me_the_cookies'

--- a/test/integration_testing/flakey_tests_test.rb
+++ b/test/integration_testing/flakey_tests_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'ndr_dev_support/integration_testing/flakey_tests'
+
+module IntegrationTesting
+  # Smoke test our minitest integration. This does not cover all functionality.
+  class FlakeyTestsTest < ActiveSupport::TestCase
+    include NdrDevSupport::IntegrationTesting::FlakeyTests
+
+    test 'should register flakey tests' do
+      refute attempts_per_test.key?(name), 'a non-flakey test should not be registered'
+      assert_equal 3, attempts_per_test.fetch('test_might_be_a_bit_flakey')
+      assert_equal 10, attempts_per_test.fetch('test_might_be_very_flakey')
+    end
+
+    test 'should not be flakey' do
+      assert true, 'we just need this to pass...'
+    end
+
+    flakey_test 'might be a bit flakey' do
+      assert true, 'we just need this to pass...'
+    end
+
+    flakey_test 'might be very flakey', attempts: 10 do
+      assert true, 'we just need this to pass...'
+    end
+  end
+end


### PR DESCRIPTION
[Minitest 5.11](https://github.com/seattlerb/minitest/blob/master/History.rdoc#label-5.11.0+-2F+2018-01-01) changed the return value of `Minitest::Test#run` to return a new intermediary `Result` object.

This PR ensures our `flakey_test` logic does the same, and raises the minitest dependency accordingly.