### PR TITLE
Code linting: don't fail when there are no linkable changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Stop linting failing when there are no lintable changes.
 
 ## 5.10.2 / 2021-02-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-### Fixed
-* Stop linting failing when there are no lintable changes.
+### Changed
+* Linting: return a zero exit status when there are no lintable changes (#97)
 
 ## 5.10.2 / 2021-02-15
 ### Fixed

--- a/lib/ndr_dev_support/rubocop/reporter.rb
+++ b/lib/ndr_dev_support/rubocop/reporter.rb
@@ -23,7 +23,7 @@ module NdrDevSupport
       # exit status for the rake task to terminate with.
       def report
         if @offenses.none?
-          puts Rainbow('No relevant changes found.').yellow
+          warn Rainbow('No relevant changes found.').yellow
           return true
         end
 

--- a/lib/ndr_dev_support/rubocop/reporter.rb
+++ b/lib/ndr_dev_support/rubocop/reporter.rb
@@ -22,15 +22,16 @@ module NdrDevSupport
       # Prints out a report, and returns an appriopriate
       # exit status for the rake task to terminate with.
       def report
-        if @offenses.any?
-          print_summary
-          puts
-          print_offenses
-          return @offenses.values.all?(&:empty?)
-        else
+        if @offenses.none?
           puts Rainbow('No relevant changes found.').yellow
-          return false
+          return true
         end
+
+        print_summary
+        puts
+        print_offenses
+
+        @offenses.values.all?(&:empty?)
       end
 
       private


### PR DESCRIPTION
A non-zero exit status means that downstream processes assume failure. In reality, we want to to fail only when there are lint issues.

This PR ensures that the exit status is zero unless linting issues are actually found. If a user has interactively run against a malformed range, they still receive a message to warn them that no changes were found to analyse.